### PR TITLE
use ghcr images in kubernetes deployment

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -12,11 +12,11 @@ jobs:
   test:
       uses: ./.github/workflows/test.yml
   build-and-push-image:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/deploy/kubernetes/bagman-deployment.yaml
+++ b/deploy/kubernetes/bagman-deployment.yaml
@@ -28,7 +28,7 @@ spec:
               value: redis
             - name: REDIS_PORT
               value: "6379"
-          image: shzl/bagman:0.0.1
+          image: ghcr.io/sheunglaili/bagman:0.0.1
           name: bagman
           ports:
             - name: socket


### PR DESCRIPTION
- add needs keyword for images publishing job
- use ghcr images for Kubernetes deployment 